### PR TITLE
Balancer lock on DE queue.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/koykov/queue
 
 go 1.16
 
-require github.com/koykov/bitset v0.0.0-20220630192021-a713ee0d389d
+require github.com/koykov/bitset v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/koykov/bitset v0.0.0-20220630192021-a713ee0d389d h1:b82iiOxU5g1mcgKfmJPg47WGLumM91t9wPNWN1a3DbM=
-github.com/koykov/bitset v0.0.0-20220630192021-a713ee0d389d/go.mod h1:Mg0YlEO6vG0Vd2N5qZhyH1ss2ZuuMZR8iYNKshQcm6I=
+github.com/koykov/bitset v1.0.0 h1:2mEbAhKelhpdWqnpa+mR3HRhdMsto5od7ACOi6MIAmk=
+github.com/koykov/bitset v1.0.0/go.mod h1:DVR3bH49c1oOcNtD38h+aQq7lp1ZY91cXmjOldlTk8A=

--- a/queue.go
+++ b/queue.go
@@ -301,9 +301,6 @@ func (q *Queue) close(force bool) error {
 	// Wait till all enqueue operations will finish.
 	for atomic.LoadInt64(&q.enqlock) > 0 {
 	}
-	// Close the stream.
-	// Please note, this is not the end for regular close case. Workers continue works while queue has items.
-	close(q.stream)
 
 	if force {
 		// Immediately stop all active/sleeping workers.
@@ -329,6 +326,10 @@ func (q *Queue) close(force bool) error {
 			}
 		}
 	}
+	// Close the stream.
+	// Please note, this is not the end for regular close case. Workers continue works while queue has items.
+	close(q.stream)
+
 	return nil
 }
 


### PR DESCRIPTION
Fixed:
- balacer locking when DE feature enabled
- interrupt waiting (DE) on force close
- return unprocessed item back to queue when interrupt